### PR TITLE
記事作成の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
 
   gem 'pry-doc'
   gem 'pry-rails'
+  gem 'pry-nav'
 
   gem 'rspec-rails', '~> 5.1.2'
   gem 'faker', '~> 3.1', '>= 3.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     pry-doc (1.4.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
+    pry-nav (1.0.0)
+      pry (>= 0.9.10, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     puma (4.3.12)
@@ -300,6 +302,7 @@ DEPENDENCIES
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
   pry-doc
+  pry-nav
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.7)

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -12,7 +12,6 @@ module Api::V1
     end
 
     def create
-      binding.pry
       article = current_user.articles.create!(article_params)
       render json: article, serializer: Api::V1::ArticleSerializer
     end
@@ -21,6 +20,5 @@ module Api::V1
       def article_params
         params.require(:article).permit(:title, :body)  # titleとbodyの変更を許可
       end
-
   end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -12,6 +12,7 @@ module Api::V1
     end
 
     def create
+      binding.pry
       article = current_user.articles.create!(article_params)
       render json: article, serializer: Api::V1::ArticleSerializer
     end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -10,5 +10,16 @@ module Api::V1
       article = Article.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      article = current_user.articles.create!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+    private  # ストロングパラメーター（予期しない値を変更されてしまう脆弱性を防ぐ機能）
+      def article_params
+        params.require(:article).permit(:title, :body)  # titleとbodyの変更を許可
+      end
+
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
+    # current_user のダミーコード
+    def current_user
+      @current_user ||= User.first
+    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
         include DeviseTokenAuth::Concerns::SetUserByToken
+        protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,6 @@ module RailsEditor
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -57,11 +57,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     context "不適切なパラメーターを送信した時" do
       let(:params) do
-        FactoryBot.attributes_for(:article)
-        binding.pry
+        {article: attributes_for(:article)}
       end
-      let(:current_user) { create(:user) }
+        let(:current_user) { create(:user) }
+
       fit "記事レコードが作成できる" do
+        binding.pry
         # 記事の取得
         expect{subject}.to change{Article.count}.by(1)
         res = JSON.parse(response.body)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -54,27 +54,23 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
   describe "POST /api/v1/articles/" do
     subject { post(api_v1_articles_path, params: params) }
+    # 【モック】事前にcurennt_userがdeviceを用いて作成されるようモックで定義
+    before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
 
-    context "不適切なパラメーターを送信した時" do
-      let(:params) do
-        {article: attributes_for(:article)}
-      end
-        let(:current_user) { create(:user) }
+    let(:params) do
+      {article: attributes_for(:article)}
+    end
+      let(:current_user) { create(:user) }
 
-      fit "記事レコードが作成できる" do
-        binding.pry
-        # 記事の取得
-        expect{subject}.to change{Article.count}.by(1)
-        res = JSON.parse(response.body)
-        # 各記事の項目がAPIで記事と作成した記事が一致するか検証
-        expect(res["title"]).to eq article.title
-        expect(res["body"]).to eq article.body
-        expect(response).to have_http_status(:ok)
-      end
+    it "記事レコードが作成できる" do
+      # 記事の取得
+      expect{subject}.to change{Article.count}.by(1)
+      res = JSON.parse(response.body)
+      # 各記事の項目がAPIで記事と作成した記事が一致するか検証
+      expect(res["title"]).to eq params[:article][:title]
+      expect(res["body"]).to eq params[:article][:body]
+      expect(response).to have_http_status(:ok)
 
-    context "不適切なパラメーターを送信した時"
-      it "レーコードの作成に失敗する"do
-      end
     end
   end
 

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -46,10 +46,35 @@ RSpec.describe "Api::V1::Articles", type: :request do
     context "指定した id の記事が存在しない場合" do
       let(:article_id) { 10000 }
 
-      fit "記事が見つからない" do
+      it "記事が見つからない" do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
-
   end
+
+  describe "POST /api/v1/articles/" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    context "不適切なパラメーターを送信した時" do
+      let(:params) do
+        FactoryBot.attributes_for(:article)
+        binding.pry
+      end
+      let(:current_user) { create(:user) }
+      fit "記事レコードが作成できる" do
+        # 記事の取得
+        expect{subject}.to change{Article.count}.by(1)
+        res = JSON.parse(response.body)
+        # 各記事の項目がAPIで記事と作成した記事が一致するか検証
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(response).to have_http_status(:ok)
+      end
+
+    context "不適切なパラメーターを送信した時"
+      it "レーコードの作成に失敗する"do
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
# 概要
- 記事作成の実装
# 詳細
- ダミーの current_userメソッド
- テストにスタブを定義
- 新規作成する記事の user_id が current_user の id になるAPI を実装
# 確認したこと
- Postmanを使って記事が作成できるか確認
## 見積もり時間　=> 実際にかかった時間
-   2h  =>   10h
## 見積もりに対して実際どうだったか
- current_user という変数を、ダミーとして base_api_controller にこのメソッドを定義して、仮実装としてusers テーブルの一番初めのユーザーとするのに時間がかかった
- 新規作成する記事の user_id が current_user の id になるような API を実装するのに時間がかかった
- どのモデルから情報の取得するのかイメージがついていなかったため
- テスト用にcurrent_userのモックの作成をするのに時間がかかった

### 参 考
- 
https://qiita.com/jnchito/items/640f17e124ab263a54dd#%E3%81%A9%E3%81%86%E3%81%97%E3%81%A6%E3%82%82%E3%83%A2%E3%83%83%E3%82%AF%E3%82%92%E6%8C%9F%E3%81%BF%E8%BE%BC%E3%82%80%E3%81%93%E3%81%A8%E3%81%8C%E3%81%A7%E3%81%8D%E3%81%AA%E3%81%84%E5%A0%B4%E5%90%88allow_any_instance_of