### PR TITLE
Devise token auth api test

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -3,7 +3,6 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
     #ユーザー登録時に使用
     def sign_up_params
-      binding.pry
       params.require(:registration).permit(:name, :email, :password,:password_confirmation)
     end
 

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       # urennt_userが記事を作成した場合
       let(:article) { create(:article, user: current_user) }
 
-      fit "記事を更新できる" do
+      it "記事を更新できる" do
         expect { subject }.to change{article.reload.title}.to(params[:article][:title])&
                               change { article.reload.body }.from(article.body).to(params[:article][:body])
         expect(response).to have_http_status(:ok)
@@ -110,7 +110,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     context "自分の記事を削除しようとしたとき" do
       let!(:article) { create(:article, user: current_user) }
 
-      fit "記事を削除できる" do
+      it "記事を削除できる" do
         expect { subject }.to change { Article.count }.by(-1)
         expect(response).to have_http_status(:no_content)
       end
@@ -120,7 +120,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       let(:other_user) { create(:user) }
       let!(:article) { create(:article, user: other_user) }
 
-      fit "記事を削除できない" do
+      it "記事を削除できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound) & change { Article.count }.by(0)
       end
     end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "POST /index" do
+    subject { post(api_v1_user_registration_path, params: params) }
+    context "必要な情報が存在するとき" do
+      it "ユーザを新規登録ができる" do
+      end
+      it "header情報を取得できる" do
+      end
+    end
+    context "name が存在しないとき" do
+      it "エラーが起きて登録できない" do
+      end
+    end
+    context "email が存在しないとき" do
+      it "エラーが起きて登録できない" do
+      end
+    end
+    context "passwordが存在しないとき" do
+      it "エラーが起きて登録できない" do
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -10,9 +10,8 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         expect(response).to have_http_status(:ok)
         res = JSON.parse(response.body)
       end
-      fit "header情報を取得できる" do
+      it "header情報を取得できる" do
         subject
-        binding.pry
         expect(response.header["access-token"]).to be_present
         expect(response.header["token-type"]).to be_present
         expect(response.header["client"]).to be_present
@@ -21,15 +20,27 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       end
     end
     context "name が存在しないとき" do
+      let(:params) {{ registration: attributes_for(:user,name: nil) }}
       it "エラーが起きて登録できない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["errors"]["name"]).to eq ["can't be blank"]
       end
     end
     context "email が存在しないとき" do
+      let(:params) {{ registration: attributes_for(:user,email: nil) }}
       it "エラーが起きて登録できない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["errors"]["email"]).to eq ["can't be blank"]
       end
     end
-    context "passwordが存在しないとき" do
+    context "password が存在しないとき" do
+      let(:params) {{ registration: attributes_for(:user,password: nil) }}
       it "エラーが起きて登録できない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["errors"]["password"]).to eq ["can't be blank"]
       end
     end
   end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       it "エラーが起きて登録できない" do
         expect { subject }.to change { User.count }.by(0)
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)["errors"]["name"]).to eq ["can't be blank"]
+        res=JSON.parse(response.body)
+        expect(res["errors"]["name"]).to eq ["can't be blank"]
       end
     end
     context "email が存在しないとき" do
@@ -32,7 +33,8 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       it "エラーが起きて登録できない" do
         expect { subject }.to change { User.count }.by(0)
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)["errors"]["email"]).to eq ["can't be blank"]
+        res=JSON.parse(response.body)
+        expect(res["errors"]["email"]).to eq ["can't be blank"]
       end
     end
     context "password が存在しないとき" do
@@ -40,7 +42,8 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       it "エラーが起きて登録できない" do
         expect { subject }.to change { User.count }.by(0)
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)["errors"]["password"]).to eq ["can't be blank"]
+        res=JSON.parse(response.body)
+        expect(res["errors"]["password"]).to eq ["can't be blank"]
       end
     end
   end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,12 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  describe "POST /index" do
+  describe "POST /v1/auth" do
     subject { post(api_v1_user_registration_path, params: params) }
     context "必要な情報が存在するとき" do
+      let(:params) {{ registration: attributes_for(:user) }}
       it "ユーザを新規登録ができる" do
+        expect { subject }.to change { User.count }.by(1)
+        expect(response).to have_http_status(:ok)
+        res = JSON.parse(response.body)
       end
-      it "header情報を取得できる" do
+      fit "header情報を取得できる" do
+        subject
+        binding.pry
+        expect(response.header["access-token"]).to be_present
+        expect(response.header["token-type"]).to be_present
+        expect(response.header["client"]).to be_present
+        expect(response.header["expiry"]).to be_present
+        expect(response.header["uid"]).to be_present
       end
     end
     context "name が存在しないとき" do

--- a/spec/requests/v1/auth/registrations_spec.rb
+++ b/spec/requests/v1/auth/registrations_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "V1::Auth::Registrations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end


### PR DESCRIPTION
# 概要
- 新規登録 API のテスト実装
# 詳細
- 必要な情報が存在するとき
- 必要な情報が存在しないとき
- 必要な情報は、name email passwordのことを指す
# 確認したこと
- テストの実行
## 見積もり時間　=> 実際にかかった時間
-   3h  =>   7h
## 見積もりに対して実際どうだったか
- headerの情報の確認の実装に時間がかかった
- 新規登録のregistration にuser情報を紐付けるのに時間がかかった