### PR TITLE
ログイン API の実装

### DIFF
--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
     context "email が一致しないとき" do
       let(:user){ create(:user)}
       let(:params) {attributes_for(:user,email: "hogehoge", paasword: user.password) }
-      fit "エラーが起きて登録できない" do
+      it "エラーが起きて登録できない" do
         subject
         #body情報
         res = JSON.parse(response.body)
@@ -40,12 +40,25 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
       end
     end
     context "password が存在しないとき" do
-      let(:params) {{ registration: attributes_for(:user,password: nil) }}
+      let(:user){ create(:user)}
+      let(:params) {attributes_for(:user,email: user.email, paasword: "hogehoge") }
       it "エラーが起きて登録できない" do
-        expect { subject }.to change { User.count }.by(0)
-        expect(response).to have_http_status(:unprocessable_entity)
-        res=JSON.parse(response.body)
-        expect(res["errors"]["password"]).to eq ["can't be blank"]
+        subject
+        #body情報
+        res = JSON.parse(response.body)
+        #hearder情報
+        header = response.headers
+
+        #bodyのエラーの確認
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
+
+        #ステータスコードの確認
+        expect(response).to have_http_status(401)
+
+        #heardersの情報がないことを確認
+        expect(response.header["access-token"]).to be_blank
+        expect(response.header["client"]).to be_blank
+        expect(response.header["uid"]).to be_blank
       end
     end
   end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+  describe "POST /v1/auth/sign_in" do
+    subject { post(api_v1_user_session_path, params: params) }
+    context "User情報が存在するとき" do
+      # ユーザーの作成
+      let(:user){ create(:user)}
+      # ユーザーのログイン情報
+      let(:params) {attributes_for(:user, email: user.email, password: user.password) }
+      it "ユーザでログインができる" do
+        subject
+        expect(response).to have_http_status(:ok)
+        expect(response.header["access-token"]).to be_present
+        expect(response.header["client"]).to be_present
+        expect(response.header["uid"]).to be_present
+      end
+    end
+
+    context "email が一致しないとき" do
+      let(:user){ create(:user)}
+      let(:params) {attributes_for(:user,email: "hogehoge", paasword: user.password) }
+      fit "エラーが起きて登録できない" do
+        subject
+        #body情報
+        res = JSON.parse(response.body)
+        #hearder情報
+        header = response.headers
+
+        #bodyのエラーの確認
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
+
+        #ステータスコードの確認
+        expect(response).to have_http_status(401)
+
+        #heardersの情報がないことを確認
+        expect(response.header["access-token"]).to be_blank
+        expect(response.header["client"]).to be_blank
+        expect(response.header["uid"]).to be_blank
+      end
+    end
+    context "password が存在しないとき" do
+      let(:params) {{ registration: attributes_for(:user,password: nil) }}
+      it "エラーが起きて登録できない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response).to have_http_status(:unprocessable_entity)
+        res=JSON.parse(response.body)
+        expect(res["errors"]["password"]).to eq ["can't be blank"]
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe "Api::V1::Auth::Sessions", type: :request do
   describe "POST /v1/auth/sign_in" do
     subject { post(api_v1_user_session_path, params: params) }
+
     context "User情報が存在するとき" do
       # ユーザーの作成
       let(:user){ create(:user)}
@@ -11,9 +12,9 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
       it "ユーザでログインができる" do
         subject
         expect(response).to have_http_status(:ok)
-        expect(response.header["access-token"]).to be_present
-        expect(response.header["client"]).to be_present
-        expect(response.header["uid"]).to be_present
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["uid"]).to be_present
       end
     end
 
@@ -34,15 +35,16 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
         expect(response).to have_http_status(401)
 
         #heardersの情報がないことを確認
-        expect(response.header["access-token"]).to be_blank
-        expect(response.header["client"]).to be_blank
-        expect(response.header["uid"]).to be_blank
+        expect(header["access-token"]).to be_blank
+        expect(header["client"]).to be_blank
+        expect(header["uid"]).to be_blank
       end
     end
+
     context "password が存在しないとき" do
       let(:user){ create(:user)}
       let(:params) {attributes_for(:user,email: user.email, paasword: "hogehoge") }
-      it "エラーが起きて登録できない" do
+      fit "エラーが起きて登録できない" do
         subject
         #body情報
         res = JSON.parse(response.body)
@@ -56,9 +58,9 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
         expect(response).to have_http_status(401)
 
         #heardersの情報がないことを確認
-        expect(response.header["access-token"]).to be_blank
-        expect(response.header["client"]).to be_blank
-        expect(response.header["uid"]).to be_blank
+        expect(header["access-token"]).to be_blank
+        expect(header["client"]).to be_blank
+        expect(header["uid"]).to be_blank
       end
     end
   end


### PR DESCRIPTION
# 概要
- ログイン API の実装
# 詳細
- ログイン API の挙動確認
- テストの実装
# 確認したこと
- ログイン時ログインできなかった時のhearder情報の違い
## 見積もり時間　=> 実際にかかった時間
-   3h  =>  5h
## 見積もりに対して実際どうだったか
- ログイン時に違う情報が何かを探るのに時間がかかった。
- エラーコードの取得に時間がかかった
### 参 考
- https://qiita.com/naokami/items/1fa3aa706fb61eb66d67
- https://qiita.com/TK_WebSE/items/e03886feaf420325de82
- https://qiita.com/tfrcm/items/e3022f1508f1b030baca
- https://qiita.com/jnchito/items/2e79a1abe7cd8214caa5
