### PR TITLE
ログアウト API の実装

### DIFF
--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -71,8 +71,10 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
     context "ログアウトに必要な情報を送信したとき" do
 			let(:user) { create(:user) }
       let!(:headers) { user.create_new_auth_token }
-      it "ログアウトできる" do
-        subject
+      fit "ログアウトできる" do
+        #header情報
+        expect { subject }.to change { user.reload.tokens }.from(be_present).to(be_blank)
+
         #body情報
         res = JSON.parse(response.body)
         expect(res["success"]).to be_truthy

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
     context "ログアウトに必要な情報を送信したとき" do
 			let(:user) { create(:user) }
       let!(:headers) { user.create_new_auth_token }
-      fit "ログアウトできる" do
+      it "ログアウトできる" do
         #header情報
         expect { subject }.to change { user.reload.tokens }.from(be_present).to(be_blank)
 

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
       let(:params) {attributes_for(:user, email: user.email, password: user.password) }
       it "ユーザでログインができる" do
         subject
+        #hearder情報
+        header = response.headers
+
         expect(response).to have_http_status(:ok)
         expect(header["access-token"]).to be_present
         expect(header["client"]).to be_present

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -64,4 +64,29 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
       end
     end
   end
+
+  describe "DELETE /api/v1/auth/sign_out" do
+    subject { delete(destroy_api_v1_user_session_path, headers: headers) }
+
+    context "ログアウトに必要な情報を送信したとき" do
+			let(:user) { create(:user) }
+      let!(:headers) { user.create_new_auth_token }
+      fit "ログアウトできる" do
+        subject
+        #body情報
+        res = JSON.parse(response.body)
+        expect(res["success"]).to be_truthy
+
+        #ステータスコードの確認
+        expect(response).to have_http_status(:ok)
+
+        binding.pry
+      end
+    end
+
+    context "誤った情報を送信したとき" do
+      it "ログアウトできない" do
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
     context "password が存在しないとき" do
       let(:user){ create(:user)}
       let(:params) {attributes_for(:user,email: user.email, paasword: "hogehoge") }
-      fit "エラーが起きて登録できない" do
+      it "エラーが起きて登録できない" do
         subject
         #body情報
         res = JSON.parse(response.body)
@@ -71,7 +71,7 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
     context "ログアウトに必要な情報を送信したとき" do
 			let(:user) { create(:user) }
       let!(:headers) { user.create_new_auth_token }
-      fit "ログアウトできる" do
+      it "ログアウトできる" do
         subject
         #body情報
         res = JSON.parse(response.body)
@@ -79,13 +79,21 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
 
         #ステータスコードの確認
         expect(response).to have_http_status(:ok)
-
-        binding.pry
       end
     end
 
     context "誤った情報を送信したとき" do
+      let(:user) { create(:user) }
+      let!(:headers) { { "access-token" => "", "client" => "", "uid" => "" } }
       it "ログアウトできない" do
+        subject
+
+        #ステータスコードの確認
+        expect(response).to have_http_status(404)
+
+        #body情報
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to include "User was not found or was not logged in."
       end
     end
   end


### PR DESCRIPTION
# 概要
- ログアウトAPIの確認
- ログアウトのテストの実装
# 詳細
- ログアウトに必要な情報がない時にログアウトできないことの確認
# 確認したこと
- 動作確認した内容を記載
## 見積もり時間　=> 実際にかかった時間
-   3h  =>   5 h
## 見積もりに対して実際どうだったか
- ログアウトのテストの実装でheader情報のtokenの知識を整理することができなかった。
- Rspecのsubjectの使用を理解ができていなかった。
### 参 考
https://qiita.com/disk131/items/a801e4bc11c8d64fed9a
https://github.com/lynndylanhurley/devise_token_auth/blob/master/docs/usage/model_concerns.md
