### PR TITLE
既存 API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -13,7 +13,6 @@ module Api::V1
     end
 
     def create
-      binding.pry
       article = current_user.articles.create!(article_params)
       render json: article, serializer: Api::V1::ArticleSerializer
     end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 module Api::V1
   class ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
     # http://localhost:3000/api/v1/articles(.:format)
     def index
       articles = Article.order('created_at desc')
@@ -12,6 +13,7 @@ module Api::V1
     end
 
     def create
+      binding.pry
       article = current_user.articles.create!(article_params)
       render json: article, serializer: Api::V1::ArticleSerializer
     end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -8,6 +8,6 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
 
     #ユーザー更新時に使用
     def account_update_params
-        params.require(:registration).permit(:name, :email)
+      params.require(:registration).permit(:name, :email)
     end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::BaseApiController < ApplicationController
     # current_user のダミーコード
-    def current_user
-      @current_user ||= User.first
-    end
+    # def current_user
+    #   binding.pry
+    #   @current_user ||= User.first
+    # end
+    alias_method :current_user, :current_api_v1_user
+    alias_method :authenticate_user!, :authenticate_api_v1_user!
+    alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -53,14 +53,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /api/v1/articles/" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
     # 【モック】事前にcurennt_userがdeviceを用いて作成されるようモックで定義
-    before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
+    # before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
 
     let(:params) {{article: attributes_for(:article)}}
     let(:current_user) { create(:user) }
 
-    it "記事レコードが作成できる" do
+    fit "記事レコードが作成できる" do
       # 記事の取得
       expect{subject}.to change{Article.count}.by(1)
       res = JSON.parse(response.body)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
     # 【モック】事前にcurennt_userがdeviceを用いて作成されるようモックで定義
     # before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
-
+    let(:headers) { current_user.create_new_auth_token }
     let(:params) {{article: attributes_for(:article)}}
     let(:current_user) { create(:user) }
 
-    fit "記事レコードが作成できる" do
+    it "記事レコードが作成できる" do
       # 記事の取得
       expect{subject}.to change{Article.count}.by(1)
       res = JSON.parse(response.body)
@@ -72,9 +72,10 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
     # 【モック】事前にcurennt_userがdeviceを用いて作成されるようモックで定義
-    before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
+    # before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
+    let(:headers) { current_user.create_new_auth_token }
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
 
@@ -101,9 +102,10 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
-
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
+    # 【モック】事前にcurennt_userがdeviceを用いて作成されるようモックで定義
+    # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
     let(:current_user) { create(:user) }
     let(:article_id) { article.id }
 


### PR DESCRIPTION
# 概要
- 既存 API の修正
# 詳細
- モックの修正
- user関連のエイリアスの作成
- （テストのみ） hearder情報（auth_token）の作成
# 確認したこと
- Postmanでの記事の作成の確認、curennt_userの確認
- テスト修正後の確認 
## 見積もり時間　=> 実際にかかった時間
-   3h  =>   9h
## 見積もりに対して実際どうだったか
- タスク内容の理解に時間がかかった
- かかった原因はrouteでnamespaceを使用したことによるルーティングの変更に気が付くことができなかった
- エイリアスの作成に気がつくのに時間がかかった
### 参 考
- https://docs.ruby-lang.org/ja/latest/method/Module/i/alias_method.html
- https://devise-token-auth.gitbook.io/devise-token-auth/usage/controller_methods
