### PR TITLE
 Article model に下書き機能を追加

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -30,7 +30,7 @@ module Api::V1
 
     private  # ストロングパラメーター（予期しない値を変更されてしまう脆弱性を防ぐ機能）
       def article_params
-        params.require(:article).permit(:title, :body, :statuss)  # titleとbodyの変更を許可
+        params.require(:article).permit(:title, :body, :status)  # titleとbodyの変更を許可
       end
   end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ module Api::V1
     before_action :authenticate_user!, only: [:create, :update, :destroy]
     # http://localhost:3000/api/v1/articles(.:format)
     def index
-      articles = Article.order('created_at desc')
+      articles = Article.published.order('created_at desc')
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
@@ -30,7 +30,7 @@ module Api::V1
 
     private  # ストロングパラメーター（予期しない値を変更されてしまう脆弱性を防ぐ機能）
       def article_params
-        params.require(:article).permit(:title, :body)  # titleとbodyの変更を許可
+        params.require(:article).permit(:title, :body, :statuss)  # titleとbodyの変更を許可
       end
   end
 end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -3,11 +3,11 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
     #ユーザー登録時に使用
     def sign_up_params
-      params.require(:registration).permit(:name, :email, :password,:password_confirmation)
+      params.permit(:name, :email, :password,:password_confirmation)
     end
 
     #ユーザー更新時に使用
     def account_update_params
-      params.require(:registration).permit(:name, :email)
+      params.permit(:name, :email)
     end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -22,4 +23,5 @@ class Article < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   validates :title,  presence: true
+  enum status: { draft: "draft", published: "published"}
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/db/migrate/20230324120831_add_status_to_articles.rb
+++ b/db/migrate/20230324120831_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :string ,default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_23_181822) do
+ActiveRecord::Schema.define(version: 2023_03_24_120831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2023_02_23_181822) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -24,5 +24,13 @@ FactoryBot.define do
     body { Faker::Lorem.characters(number: Random.new.rand(1..30)) }
     #association :user, factory: :user
     user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  image                  :string
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     name { Faker::Name.name }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -23,10 +23,28 @@ require 'rails_helper'
 RSpec.describe Article, type: :model do
   context "必要情報が揃っている" do
     let(:article){build(:article)}
-    it "記事ができる" do
+    it "下書き状態の記事が作成できる" do
       expect(article).to be_valid
+      expect(article.status).to eq "draft"
     end
   end
+
+  context "status が下書き状態のとき" do
+    let(:article){build(:article, :draft)}
+    it "記事を下書き状態で作成できる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "draft"
+    end
+  end
+
+  context "status が公開状態のとき" do
+    let(:article){build(:article, :published)}
+    it "記事を公開状態で作成できる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "published"
+    end
+  end
+
 
   context "タイトルの記入なし" do
     let(:article){build(:article, title: nil)}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  image                  :string
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 require 'rails_helper'
 
 RSpec.describe User, type: :model do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     context"ステータス：下書き　の場合" do
       let(:params) { { article: attributes_for(:article, :draft) } }
-      fit "記事のレコードが作成できる" do
+      it "記事のレコードが作成できる" do
         # 記事の取得
         expect{subject}.to change{Article.where(user_id: current_user.id).count}.by(1)
         res = JSON.parse(response.body)
@@ -98,8 +98,9 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
     context"ステータス　が指定されたもの以外の場合" do
-      let(:params) { { article: attributes_for(:article, :nil) } }
-      it "エラーになる" do
+      let(:params) { { article: attributes_for(:article, status: :hogehoge) } }
+      fit "エラーになる" do
+        expect { subject }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     context"ステータス：公開　の場合" do
       let(:params) { { article: attributes_for(:article, :published) } }
+      it "記事のレコードが作成できる" do
+        # 記事の取得
+        expect{subject}.to change{Article.where(user_id: current_user.id).count}.by(1)
+        res = JSON.parse(response.body)
+        # 各記事の項目がAPIで記事と作成した記事が一致するか検証
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(res["status"]).to eq "published"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context"ステータス：下書き　の場合" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
       fit "記事のレコードが作成できる" do
         # 記事の取得
         expect{subject}.to change{Article.where(user_id: current_user.id).count}.by(1)
@@ -78,12 +92,9 @@ RSpec.describe "Api::V1::Articles", type: :request do
         # 各記事の項目がAPIで記事と作成した記事が一致するか検証
         expect(res["title"]).to eq params[:article][:title]
         expect(res["body"]).to eq params[:article][:body]
+        expect(res["status"]).to eq "draft"
         expect(response).to have_http_status(:ok)
-      end
-    end
-    context"ステータス：下書き　の場合" do
-      let(:params) { { article: attributes_for(:article, :draft) } }
-      it "記事のレコードが作成できる" do
+
       end
     end
     context"ステータス　が指定されたもの以外の場合" do
@@ -91,23 +102,6 @@ RSpec.describe "Api::V1::Articles", type: :request do
       it "エラーになる" do
       end
     end
-
-
-
-
-
-
-    it "記事レコードが作成できる" do
-      # 記事の取得
-      expect{subject}.to change{Article.count}.by(1)
-      res = JSON.parse(response.body)
-      # 各記事の項目がAPIで記事と作成した記事が一致するか検証
-      expect(res["title"]).to eq params[:article][:title]
-      expect(res["body"]).to eq params[:article][:body]
-      expect(response).to have_http_status(:ok)
-    end
-
-
   end
 
   describe "PATCH /api/v1/articles/:id" do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
     context"ステータス　が指定されたもの以外の場合" do
       let(:params) { { article: attributes_for(:article, status: :hogehoge) } }
-      fit "エラーになる" do
+      it "エラーになる" do
         expect { subject }.to raise_error(ArgumentError)
       end
     end
@@ -110,16 +110,17 @@ RSpec.describe "Api::V1::Articles", type: :request do
     # 【モック】事前にcurennt_userがdeviceを用いて作成されるようモックで定義
     # before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
     let(:headers) { current_user.create_new_auth_token }
-    let(:params) { { article: attributes_for(:article) } }
+    let(:params) { { article: attributes_for(:article ,:published) } }
     let(:current_user) { create(:user) }
 
     context "自分が所持している記事のレコードを更新しようとするとき" do
       # urennt_userが記事を作成した場合
-      let(:article) { create(:article, user: current_user) }
+      let(:article) { create(:article, :draft, user: current_user) }
 
       it "記事を更新できる" do
         expect { subject }.to change{article.reload.title}.to(params[:article][:title])&
-                              change { article.reload.body }.from(article.body).to(params[:article][:body])
+                              change { article.reload.body }.from(article.body).to(params[:article][:body])&
+                              change { article.reload.status }.from(article.status).to(params[:article][:status].to_s)
         expect(response).to have_http_status(:ok)
       end
     end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -67,8 +67,30 @@ RSpec.describe "Api::V1::Articles", type: :request do
     # 【モック】事前にcurennt_userがdeviceを用いて作成されるようモックで定義
     # before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
     let(:headers) { current_user.create_new_auth_token }
-    let(:params) {{article: attributes_for(:article)}}
     let(:current_user) { create(:user) }
+
+    context"ステータス：公開　の場合" do
+      let(:params) { { article: attributes_for(:article, :published) } }
+      fit "記事のレコードが作成できる" do
+        # 記事の取得
+        expect{subject}.to change{Article.where(user_id: current_user.id).count}.by(1)
+        res = JSON.parse(response.body)
+        # 各記事の項目がAPIで記事と作成した記事が一致するか検証
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+    context"ステータス：下書き　の場合" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
+      it "記事のレコードが作成できる" do
+      end
+    end
+    context"ステータス　が指定されたもの以外の場合" do
+      let(:params) { { article: attributes_for(:article, :nil) } }
+      it "エラーになる" do
+      end
+    end
 
 
 


### PR DESCRIPTION
# 概要
-  Article model に下書き機能を追加
- 既存APIの修正
# 詳細
- 記事の下書きと公開を追加
- 記事の状態に関するカラムの追加
- 記事の models spec に上記実装をテスト
- 記事に関する既存APIの修正・テストの実装
# 確認したこと
- データベースのカラムの変化の確認
- CRAD処理の挙動の確認
- テストの修正
## 見積もり時間　=> 実際にかかった時間
-   7h  =>   10.5h
## 見積もりに対して実際どうだったか
- 記事の model に enum を使って下書きと公開する方法を探るのに時間がかかった
- テストの状態の変化を作成するのに時間がかった
- ストロングパラメーターのタイポミスに気がつくのに2時間かかった
### 参 考
https://qiita.com/Hashimoto-Noriaki/items/be3cfe2261493df60832
https://qiita.com/shizuma/items/d133b18f8093df1e9b70
