### PR TITLE
下書き記事の一覧・詳細 のAPI実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,15 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    # before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.draft.order('created_at desc')
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+  end
+end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
     #ユーザー登録時に使用
     def sign_up_params
-      params.permit(:name, :email, :password,:password_confirmation)
+      params.permit(:name, :email, :password, :password_confirmation)
     end
 
     #ユーザー更新時に使用

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
   root to: "home#index"
 
-  # # reload 対策
-  # get "sign_up", to: "home#index"
-  # get "sign_in", to: "home#index"
-  # get "articles/new", to: "home#index"
-  # get "articles/:id", to: "home#index"
+  # reload 対策
+  get "sign_up", to: "home#index"
+  get "sign_in", to: "home#index"
+  get "articles/new", to: "home#index"
+  get "articles/:id", to: "home#index"
 
   namespace :api do
     namespace :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
   root to: "home#index"
 
-  # reload 対策
-  get "sign_up", to: "home#index"
-  get "sign_in", to: "home#index"
-  get "articles/new", to: "home#index"
-  get "articles/:id", to: "home#index"
+  # # reload 対策
+  # get "sign_up", to: "home#index"
+  # get "sign_in", to: "home#index"
+  # get "articles/new", to: "home#index"
+  # get "articles/:id", to: "home#index"
 
   namespace :api do
     namespace :v1 do
@@ -13,6 +13,11 @@ Rails.application.routes.draw do
         registrations: "api/v1/auth/registrations",
       }
       resources :articles
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
+      resources :articles
+
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
-      resources :articles
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  let(:headers) { current_user.create_new_auth_token }
+  let(:current_user) { create(:user) }
+  describe "GET /api/v1/articles/drafts" do
+    context "自分の書いた下書きの記事が存在するとき" do
+      it "自分の書いた下書きのみが取得できる" do
+      end
+    end
+  end
+
+  describe "GET /articles/drafts/:id" do
+    context "指定した id の記事が存在して" do
+      context "対象の記事が自分が書いた下書きのとき" do
+        it "記事の詳細を取得できる" do
+        end
+      end
+      context "対象の記事が他のユーザーが書いた下書きのとき" do
+        it "記事が見つからない" do
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -2,9 +2,26 @@ require 'rails_helper'
 RSpec.describe "Api::V1::Articles::Drafts", type: :request do
   let(:headers) { current_user.create_new_auth_token }
   let(:current_user) { create(:user) }
+
   describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
     context "自分の書いた下書きの記事が存在するとき" do
-      it "自分の書いた下書きのみが取得できる" do
+      # ログインユーザーの記事
+      let!(:article1) { create(:article, :draft, user: current_user) }
+      # それ以外の記事
+      let!(:article2) { create(:article, :draft) }
+
+      fit "自分の書いた下書きのみが取得できる" do
+        binding.pry
+        subject
+        res = JSON.parse(response.body)
+        # 配列の要素の数を確認
+        expect(res.length).to eq 1
+        expect(res[0]["id"]).to eq article1.id
+        # 記事のKeyが一致しているか確認
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        # ユーザーのKeyが一致しているか確認
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
       end
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
       # それ以外の記事
       let!(:article2) { create(:article, :draft) }
 
-      fit "自分の書いた下書きのみが取得できる" do
-        binding.pry
+      it "自分の書いた下書きのみが取得できる" do
         subject
         res = JSON.parse(response.body)
         # 配列の要素の数を確認
@@ -27,13 +26,28 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
   end
 
   describe "GET /articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
     context "指定した id の記事が存在して" do
       context "対象の記事が自分が書いた下書きのとき" do
+        let(:article) { create(:article, :draft, user: current_user) }
+        let(:article_id) { article.id }
         it "記事の詳細を取得できる" do
+          subject
+          res = JSON.parse(response.body)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["status"]).to eq article.status
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
         end
       end
       context "対象の記事が他のユーザーが書いた下書きのとき" do
+        let(:article) { create(:article, :draft) }
+        let(:article_id) { article.id }
         it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
         end
       end
     end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
   describe "GET /articles/drafts/:id" do
     subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
     context "指定した id の記事が存在して" do
+      let(:article_id) { article.id }
       context "対象の記事が自分が書いた下書きのとき" do
         let(:article) { create(:article, :draft, user: current_user) }
-        let(:article_id) { article.id }
         it "記事の詳細を取得できる" do
           subject
           res = JSON.parse(response.body)
@@ -45,7 +45,6 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
       end
       context "対象の記事が他のユーザーが書いた下書きのとき" do
         let(:article) { create(:article, :draft) }
-        let(:article_id) { article.id }
         it "記事が見つからない" do
           expect { subject }.to raise_error ActiveRecord::RecordNotFound
         end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /v1/auth" do
     subject { post(api_v1_user_registration_path, params: params) }
     context "必要な情報が存在するとき" do
-      let(:params) {{ registration: attributes_for(:user) }}
+      let(:params) { attributes_for(:user) }
       it "ユーザを新規登録ができる" do
         expect { subject }.to change { User.count }.by(1)
         expect(response).to have_http_status(:ok)
@@ -20,7 +20,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       end
     end
     context "name が存在しないとき" do
-      let(:params) {{ registration: attributes_for(:user,name: nil) }}
+      let(:params) { attributes_for(:user,name: nil) }
       it "エラーが起きて登録できない" do
         expect { subject }.to change { User.count }.by(0)
         expect(response).to have_http_status(:unprocessable_entity)
@@ -29,7 +29,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       end
     end
     context "email が存在しないとき" do
-      let(:params) {{ registration: attributes_for(:user,email: nil) }}
+      let(:params) { attributes_for(:user,email: nil) }
       it "エラーが起きて登録できない" do
         expect { subject }.to change { User.count }.by(0)
         expect(response).to have_http_status(:unprocessable_entity)
@@ -37,8 +37,9 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         expect(res["errors"]["email"]).to eq ["can't be blank"]
       end
     end
+
     context "password が存在しないとき" do
-      let(:params) {{ registration: attributes_for(:user,password: nil) }}
+      let(:params) { attributes_for(:user,password: nil) }
       it "エラーが起きて登録できない" do
         expect { subject }.to change { User.count }.by(0)
         expect(response).to have_http_status(:unprocessable_entity)


### PR DESCRIPTION
# 概要
- 下書き記事の一覧・詳細 のAPI実装
- そのテストの実装
# 詳細
- ルーティングの修正
# 確認したこと
- ログイユーザーの書いたdraftタグのついた記事一覧が表示できるか
## 見積もり時間　=> 実際にかかった時間
-   3h  =>   13h
## 見積もりに対して実際どうだったか
- ルーティングの理解 
- Postmanでのログイン状態の再現（header情報の使用）ができるようになるのに時間がかかった
